### PR TITLE
Add ability to cancel Gossip Sync

### DIFF
--- a/mobile/speedloader.go
+++ b/mobile/speedloader.go
@@ -343,6 +343,7 @@ func downloadPatch(cacheDir string, log *Logger, dgraphHash string, patchURL str
 			return err
 		}
 		req.Header.Add("Accept-Encoding", "br, gzip")
+		req = req.WithContext(globalCtx)
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Println(err.Error())
@@ -403,6 +404,7 @@ func downloadGraph(cacheDir string, dgraphPath string, log *Logger, breezURL str
 			return err
 		}
 		req.Header.Add("Accept-Encoding", "br, gzip")
+		req = req.WithContext(globalCtx)
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Println(err.Error())
@@ -483,6 +485,7 @@ func GossipSync(serviceUrl string, cacheDir string, dataDir string, networkType 
 			callback.OnError(err)
 			return
 		}
+		req = req.WithContext(globalCtx)
 		resp, err := client.Do(req)
 		if err != nil {
 			callback.OnError(err)
@@ -604,6 +607,7 @@ func GossipSync(serviceUrl string, cacheDir string, dataDir string, networkType 
 							callback.OnError(err)
 							return
 						}
+						req = req.WithContext(globalCtx)
 						resp, err := client.Do(req)
 						if err != nil {
 							callback.OnError(err)


### PR DESCRIPTION
In integrating Speedloader into ZEUS, we discovered that some users were facing frustrations being with sync times in some situations due to poor network connections. In order to skip the sync, they would have to disable Speedloader (called Express Graph Sync in ZEUS) in Settings and then restart the app.

This PR adds a new function, `CancelGossipSync` that cancels the `GossipSync` function using a newly added global context.

[Related ZEUS issue](https://github.com/ZeusLN/zeus/issues/2026)