### PR TITLE
Update for LND v0.18.4-beta

### DIFF
--- a/mobile/speedloader.go
+++ b/mobile/speedloader.go
@@ -221,7 +221,7 @@ func ourNode(chanDB *channeldb.DB) (*channeldb.LightningNode, error) {
 	return node, err
 }
 
-func ourData(chanDB *channeldb.DB, tx walletdb.ReadWriteTx, ourNode *channeldb.LightningNode, log *Logger) (
+func ourData(chanDB *channeldb.DB, ourNode *channeldb.LightningNode, log *Logger) (
 	[]*channeldb.LightningNode, []*models.ChannelEdgeInfo, []*models.ChannelEdgePolicy, error) {
 	nodeMap := make(map[string]*channeldb.LightningNode)
 	var edges []*models.ChannelEdgeInfo
@@ -235,7 +235,7 @@ func ourData(chanDB *channeldb.DB, tx walletdb.ReadWriteTx, ourNode *channeldb.L
 		return nodes, edges, policies, globalCtx.Err()
 	default:
 		graph := chanDB.ChannelGraph()
-		err := graph.ForEachNodeChannel(tx, ourNode.PubKeyBytes, func(tx walletdb.ReadTx,
+		err := graph.ForEachNodeChannel(ourNode.PubKeyBytes, func(tx walletdb.ReadTx,
 			channelEdgeInfo *models.ChannelEdgeInfo,
 			toPolicy *models.ChannelEdgePolicy,
 			fromPolicy *models.ChannelEdgePolicy) error {
@@ -789,7 +789,7 @@ func GossipSync(serviceUrl string, cacheDir string, dataDir string, networkType 
 			//errors.New("source node was set before sync transaction, rolling back").Error()
 		}
 		if ourNode != nil {
-			channelNodes, channels, policies, err := ourData(destDB, kvdbTx, ourNode, log)
+			channelNodes, channels, policies, err := ourData(destDB, ourNode, log)
 			if err != nil {
 				callback.OnError(err)
 				return


### PR DESCRIPTION
When building ZEUS' LND fork for `v0.18.4-beta` we hit the following issue on build:

```
/Users/evan/go/src/lnd/mobile/speedloader.go:238:60: too many arguments in call to graph.ForEachNodeChannel
	have (walletdb.ReadWriteTx, [33]byte, func(tx walletdb.ReadTx, channelEdgeInfo *models.ChannelEdgeInfo, toPolicy *models.ChannelEdgePolicy, fromPolicy *models.ChannelEdgePolicy) error)
	want ("github.com/lightningnetwork/lnd/routing/route".Vertex, func(walletdb.ReadTx, *models.ChannelEdgeInfo, *models.ChannelEdgePolicy, *models.ChannelEdgePolicy) error)
github.com/lightningnetwork/lnd/mobile
# github.com/lightningnetwork/lnd/mobile
/Users/evan/go/src/lnd/mobile/speedloader.go:238:60: too many arguments in call to graph.ForEachNodeChannel
	have (walletdb.ReadWriteTx, [33]byte, func(tx walletdb.ReadTx, channelEdgeInfo *models.ChannelEdgeInfo, toPolicy *models.ChannelEdgePolicy, fromPolicy *models.ChannelEdgePolicy) error)
	want ("github.com/lightningnetwork/lnd/routing/route".Vertex, func(walletdb.ReadTx, *models.ChannelEdgeInfo, *models.ChannelEdgePolicy, *models.ChannelEdgePolicy) error)
# github.com/lightningnetwork/lnd/mobile
/Users/evan/go/src/lnd/mobile/speedloader.go:238:60: too many arguments in call to graph.ForEachNodeChannel
	have (walletdb.ReadWriteTx, [33]byte, func(tx walletdb.ReadTx, channelEdgeInfo *models.ChannelEdgeInfo, toPolicy *models.ChannelEdgePolicy, fromPolicy *models.ChannelEdgePolicy) error)
	want ("github.com/lightningnetwork/lnd/routing/route".Vertex, func(walletdb.ReadTx, *models.ChannelEdgeInfo, *models.ChannelEdgePolicy, *models.ChannelEdgePolicy) error)
/Users/evan/go/bin/gomobile: ios/arm64: go build -tags mobile,appengine,autopilotrpc,chainrpc,invoicesrpc,neutrinorpc,peersrpc,signrpc,wtclientrpc,watchtowerrpc,routerrpc,walletrpc,verrpc -v -ldflags  -s -w -buildid= -X github.com/lightningnetwork/lnd/build.Commit=v0.18.4-beta-zeus -buildmode=c-archive -o /var/folders/ss/yc50zpqs5x9_6mpfzv80s2t00000gn/T/gomobile-work-888747504/Lndmobile-ios-arm64.a ./gobind failed: exit status 1
```

Which appears to be due to this commit: https://github.com/lightningnetwork/lnd/commit/e9c89ae0ec3c846b1fa84a4d879cdf200804a71f


Testing on iOS simulator with a fresh install, and with a graph reset.